### PR TITLE
Transmission Trap Compatibility

### DIFF
--- a/Starcraft2HotSClient.py
+++ b/Starcraft2HotSClient.py
@@ -229,6 +229,7 @@ class SC2Context(CommonContext):
     mission_id_to_location_ids: typing.Dict[int, typing.List[int]] = {}
     last_bot: typing.Optional[ArchipelagoBot] = None
     temp_items = queue.Queue()
+    transmissions_per_trap = 1
 
     def __init__(self, *args, **kwargs):
         super(SC2Context, self).__init__(*args, **kwargs)
@@ -260,6 +261,7 @@ class SC2Context(CommonContext):
             self.levels_per_check = args["slot_data"].get("kerrigan_levels_per_check", 0)
             self.checks_per_level = args["slot_data"].get("kerrigan_checks_per_level_pack", 1)
             self.kerrigan_primal_status = args["slot_data"].get("kerrigan_primal_status", 0)
+            self.transmissions_per_trap = args["slot_data"].get("transmissions_per_trap", 1)
 
             self.build_location_to_mission_mapping()
 
@@ -724,7 +726,8 @@ class ArchipelagoBot(sc2.bot_ai.BotAI):
                     if not self.ctx.temp_items.empty() and iteration > self.last_temp_item_iteration + self.temp_item_delay:
                         item_name = self.ctx.temp_items.get(timeout=1)
                         if item_name == "Transmission Trap":
-                            await self.chat_send('t')
+                            for _ in range(self.ctx.transmissions_per_trap):
+                                await self.chat_send('t')
                         self.last_temp_item_iteration = iteration
                     if game_state & (1 << 1) and not self.mission_completed:
                         if self.mission_id != self.ctx.final_mission:

--- a/Starcraft2HotSClient.py
+++ b/Starcraft2HotSClient.py
@@ -708,7 +708,7 @@ class ArchipelagoBot(sc2.bot_ai.BotAI):
                     current_items[0], current_items[1], current_items[2], current_items[3], current_items[4],
                     current_items[5]))
                 # Storing temporary items
-                new_items = self.ctx.items_received[self.last_received_update - 1:len(self.ctx.items_received)]
+                new_items = self.ctx.items_received[self.last_received_update:]
                 for network_item in new_items:
                     name: str = lookup_id_to_name[network_item.item]
                     item_data: ItemData = item_table[name]

--- a/Starcraft2HotSClient.py
+++ b/Starcraft2HotSClient.py
@@ -653,7 +653,7 @@ class ArchipelagoBot(sc2.bot_ai.BotAI):
     can_read_game = False
 
     last_temp_item_iteration: int = 0
-    temp_item_delay = 160
+    temp_item_delay = 60
     last_received_update: int = 0
 
     def __init__(self, ctx: SC2Context, mission_id):
@@ -723,7 +723,9 @@ class ArchipelagoBot(sc2.bot_ai.BotAI):
 
                 if self.can_read_game:
                     # Sending temporary items
-                    if not self.ctx.temp_items.empty() and iteration > self.last_temp_item_iteration + self.temp_item_delay:
+                    if not self.ctx.temp_items.empty()\
+                       and iteration > self.last_temp_item_iteration + self.temp_item_delay\
+                       and not self.mission_completed:
                         item_name = self.ctx.temp_items.get(timeout=1)
                         if item_name == "Transmission Trap":
                             for _ in range(self.ctx.transmissions_per_trap):

--- a/worlds/sc2hots/Items.py
+++ b/worlds/sc2hots/Items.py
@@ -231,6 +231,8 @@ item_table = {
     "+15 Starting Vespene": ItemData(801 + SC2HOTS_ITEM_ID_OFFSET, "Vespene", 15, quantity=0, classification=ItemClassification.filler),
     "+2 Starting Supply": ItemData(802 + SC2HOTS_ITEM_ID_OFFSET, "Supply", 2, quantity=0, classification=ItemClassification.filler),
 
+    "Transmission Trap": ItemData(803 + SC2HOTS_ITEM_ID_OFFSET, "Trap", 0, quantity=0, classification=ItemClassification.trap)
+
     # "Keystone Piece": ItemData(850 + SC2HOTS_ITEM_ID_OFFSET, "Goal", 0, quantity=0, classification=ItemClassification.progression_skip_balancing)
 }
 
@@ -315,5 +317,6 @@ type_flaggroups: typing.Dict[str, int] = {
     "Minerals": 6,
     "Vespene": 7,
     "Supply": 8,
-    "Goal": 9
+    "Goal": 9,
+    "Trap": 10
 }

--- a/worlds/sc2hots/Options.py
+++ b/worlds/sc2hots/Options.py
@@ -236,6 +236,14 @@ class TrapPercentage(Range):
     default = 0
 
 
+class TransmissionsPerTrap(Range):
+    """Number of transmissions played per Transmission Trap"""
+    display_name = "Transmissions per Trap"
+    range_start = 0
+    range_end = 10
+    default = 1
+
+
 # class UpgradeBonus(Choice):
 #     """Determines what lab upgrade to use, whether it is Ultra-Capacitors which boost attack speed with every weapon
 #     upgrade or Vanadium Plating which boosts life with every armor upgrade."""
@@ -307,6 +315,7 @@ sc2hots_options: Dict[str, Option] = {
     "start_primary_abilities": StartPrimaryAbilities,
     "kerrigan_primal_status": KerriganPrimalStatus,
     "trap_percentage": TrapPercentage,
+    "transmissions_per_trap": TransmissionsPerTrap,
     # "upgrade_bonus": UpgradeBonus,
     # "bunker_upgrade": BunkerUpgrade,
     # "all_in_map": AllInMap,

--- a/worlds/sc2hots/Options.py
+++ b/worlds/sc2hots/Options.py
@@ -228,6 +228,14 @@ class KerriganPrimalStatus(Choice):
     option_half_completion = 4
 
 
+class TrapPercentage(Range):
+    """Percentage of the item pool to be replaced with Transmission Traps."""
+    display_name = "Trap Percentage"
+    range_start = 0
+    range_end = 75
+    default = 0
+
+
 # class UpgradeBonus(Choice):
 #     """Determines what lab upgrade to use, whether it is Ultra-Capacitors which boost attack speed with every weapon
 #     upgrade or Vanadium Plating which boosts life with every armor upgrade."""
@@ -298,6 +306,7 @@ sc2hots_options: Dict[str, Option] = {
     "include_all_kerrigan_abilities": IncludeAllKerriganAbilities,
     "start_primary_abilities": StartPrimaryAbilities,
     "kerrigan_primal_status": KerriganPrimalStatus,
+    "trap_percentage": TrapPercentage,
     # "upgrade_bonus": UpgradeBonus,
     # "bunker_upgrade": BunkerUpgrade,
     # "all_in_map": AllInMap,

--- a/worlds/sc2hots/PoolFilter.py
+++ b/worlds/sc2hots/PoolFilter.py
@@ -282,13 +282,11 @@ class ValidInventory:
 
 
 def filter_items(multiworld: MultiWorld, player: int, mission_req_table: Dict[str, MissionInfo], location_cache: List[Location],
-                 item_pool: List[Item], existing_items: List[Item], locked_items: List[Item]) -> List[Item]:
+                 item_pool: List[Item], existing_items: List[Item], locked_items: List[Item], inventory_size: int) -> List[Item]:
     """
     Returns a semi-randomly pruned set of items based on number of available locations.
     The returned inventory must be capable of logically accessing every location in the world.
     """
-    open_locations = [location for location in location_cache if location.item is None]
-    inventory_size = len(open_locations)
     # has_protoss = bool(PROTOSS_REGIONS.intersection(mission_req_table.keys()))
     mission_requirements = [location.access_rule for location in location_cache]
     valid_inventory = ValidInventory(multiworld, player, item_pool, existing_items, locked_items)

--- a/worlds/sc2hots/__init__.py
+++ b/worlds/sc2hots/__init__.py
@@ -257,8 +257,14 @@ def get_item_pool(multiworld: MultiWorld, player: int, mission_req_table: Dict[s
             pool.remove(invalid_upgrade)
     
     fill_pool_with_kerrigan_levels(multiworld, player, pool)
+    inventory_size = len([location for location in location_cache if location.item is None])
+    trap_count = int(inventory_size * get_option_value(multiworld, player, "trap_percentage") / 100)
+    inventory_size -= trap_count
+    filtered_pool = filter_items(multiworld, player, mission_req_table, location_cache,
+                                 pool, existing_items, locked_items, inventory_size)
+    for _ in range(trap_count):
+        filtered_pool.append(create_item_with_correct_settings(player, "Transmission Trap"))
 
-    filtered_pool = filter_items(multiworld, player, mission_req_table, location_cache, pool, existing_items, locked_items)
     return filtered_pool
 
 


### PR DESCRIPTION
Adds a Trap Percentage option (which replaces up to 75% of the item pool with Transmission Traps) and a Transmissions Per Trap option.

Traps are stored in a temporary item queue when received during a mission and sent when possible, with at least 60 iterations between activations.  Traps from mission victory (and traps received between victory and the game closing) will be delayed until the next mission.

Traps received between missions will currently not activate-may need to move adding traps to the queue to SC2Context, but I'm out of time for the rest of the week.