### PR TITLE
Item Name Groups for hints

### DIFF
--- a/worlds/sc2hots/Items.py
+++ b/worlds/sc2hots/Items.py
@@ -279,6 +279,9 @@ def get_basic_units(multiworld: MultiWorld, player: int) -> typing.Set[str]:
 item_name_groups = {}
 for item, data in item_table.items():
     item_name_groups.setdefault(data.type, []).append(item)
+    if data.type in ("Mutation", "Strain", "Ability") and '(' in item:
+        short_name = item[:item.find(' (')]
+        item_name_groups[short_name] = [item]
 item_name_groups["Missions"] = ["Beat " + mission_name for mission_name in vanilla_mission_req_table]
 
 filler_items: typing.Tuple[str, ...] = (


### PR DESCRIPTION
Adds a mapping for Mutations/Strains/Abilities to item name groups that does not contain the parentheses (i.e. Mend -> Mend (Kerrigan Tier 4)) to make hinting easier.